### PR TITLE
Retrieve scan

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -35,11 +35,11 @@ func run() error {
 	if err != nil {
 		return err
 	}
-
 	natsConn, err := natsio.Connect(cfg.Nats.URI)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to connect to NATS. exiting")
 	}
+	logger.Info().Strs("servers", natsConn.Servers()).Msg("connected to NATS")
 	n := natsio.New(
 		natsConn, logger, cfg, dbConn,
 	)

--- a/internal/request/forms.go
+++ b/internal/request/forms.go
@@ -60,3 +60,10 @@ func ReadInt(qs *string, key string, defaultValue int64, v *validator.Validator)
 	}
 	return int64(i)
 }
+
+func ReadString(qs *string, defaultValue string) string {
+	if qs == nil {
+		return defaultValue
+	}
+	return *qs
+}

--- a/internal/server/api_handlers.go
+++ b/internal/server/api_handlers.go
@@ -6,6 +6,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/danielmichaels/onpicket/internal/database"
 	natsio "github.com/danielmichaels/onpicket/internal/nats"
 	"github.com/danielmichaels/onpicket/internal/request"
@@ -14,9 +17,9 @@ import (
 	"github.com/danielmichaels/onpicket/internal/validator"
 	"github.com/danielmichaels/onpicket/internal/version"
 	"github.com/danielmichaels/onpicket/pkg/api"
+	"github.com/go-chi/chi/v5"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"net/http"
 )
 
 // generateName creates a random name for use in identifiers
@@ -33,18 +36,28 @@ func (app *Application) Healthz(w http.ResponseWriter, _ *http.Request) {
 	}
 	_ = response.JSON(w, http.StatusOK, health)
 }
-
+func sortDirection(s string) bson.D {
+	switch strings.ToLower(s) {
+	case "asc":
+		return bson.D{{Key: "_id", Value: -1}}
+	case "desc":
+		return bson.D{{Key: "_id", Value: 1}}
+	default:
+		return bson.D{{Key: "_id", Value: -1}}
+	}
+}
 func (app *Application) ListScans(w http.ResponseWriter, r *http.Request, params api.ListScansParams) {
 	var v validator.Validator
 
 	pageNo := request.ReadInt(params.Page, "page", 1, &v)
 	pageSize := request.ReadInt(params.PageSize, "page_size", 20, &v)
+	sort := request.ReadString(params.Sort, "asc")
 	if v.HasErrors() {
 		app.apiValidationError(w, v.FieldErrors)
 		return
 	}
 
-	opts := options.Find().SetLimit(pageSize).SetSkip((pageNo - 1) * pageSize)
+	opts := options.Find().SetLimit(pageSize).SetSkip((pageNo - 1) * pageSize).SetSort(sortDirection(sort))
 	filter := bson.D{}
 	cursor, err := app.DB.Collection(database.ScanCollection).Find(context.TODO(), filter, opts)
 	if err != nil {
@@ -66,6 +79,34 @@ func (app *Application) ListScans(w http.ResponseWriter, r *http.Request, params
 	_ = response.JSON(w, http.StatusOK, Envelope{
 		"data":     data,
 		"metadata": services.CalculateMetadata(total, pageNo, pageSize)})
+}
+
+func (app *Application) RetrieveScan(w http.ResponseWriter, r *http.Request, id string) {
+	var v validator.Validator
+	paramId := chi.URLParam(r, "id")
+
+	v.CheckField(validator.NotBlank(id), "id", "scan_id must be provided")
+	if v.HasErrors() {
+		app.apiValidationError(w, v.FieldErrors)
+		return
+	}
+
+	filter := bson.D{{Key: "id", Value: paramId}}
+	cursor, err := app.DB.Collection(database.ScanCollection).Find(context.TODO(), filter, nil)
+	if err != nil {
+		app.notFound(w, r)
+		return
+	}
+
+	var data []services.NmapScanOut
+	if err = cursor.All(context.TODO(), &data); err != nil {
+		app.Error(w, http.StatusInternalServerError, err.Error(), nil)
+		return
+	}
+	_ = response.JSON(w, http.StatusOK, Envelope{
+		"id":   paramId,
+		"data": data,
+	})
 }
 
 func (app *Application) CreateScan(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/api_handlers.go
+++ b/internal/server/api_handlers.go
@@ -2,13 +2,7 @@ package server
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/danielmichaels/onpicket/internal/database"
 	natsio "github.com/danielmichaels/onpicket/internal/nats"
 	"github.com/danielmichaels/onpicket/internal/request"
@@ -20,14 +14,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"net/http"
 )
-
-// generateName creates a random name for use in identifiers
-func generateName(s string) string {
-	b := make([]byte, 4)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("%s-%s", s, hex.EncodeToString(b))
-}
 
 func (app *Application) Healthz(w http.ResponseWriter, _ *http.Request) {
 	health := api.Healthz{
@@ -36,16 +24,7 @@ func (app *Application) Healthz(w http.ResponseWriter, _ *http.Request) {
 	}
 	_ = response.JSON(w, http.StatusOK, health)
 }
-func sortDirection(s string) bson.D {
-	switch strings.ToLower(s) {
-	case "asc":
-		return bson.D{{Key: "_id", Value: -1}}
-	case "desc":
-		return bson.D{{Key: "_id", Value: 1}}
-	default:
-		return bson.D{{Key: "_id", Value: -1}}
-	}
-}
+
 func (app *Application) ListScans(w http.ResponseWriter, r *http.Request, params api.ListScansParams) {
 	var v validator.Validator
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"go.mongodb.org/mongo-driver/bson"
+	"strings"
+)
+
+// generateName creates a random name for use in identifiers
+func generateName(s string) string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%s-%s", s, hex.EncodeToString(b))
+}
+
+// sortDirection will return a mongo bson sortable.
+func sortDirection(s string) bson.D {
+	switch strings.ToLower(s) {
+	case "asc":
+		return bson.D{{Key: "_id", Value: -1}}
+	case "desc":
+		return bson.D{{Key: "_id", Value: 1}}
+	default:
+		return bson.D{{Key: "_id", Value: -1}}
+	}
+}

--- a/internal/services/nmap.go
+++ b/internal/services/nmap.go
@@ -33,9 +33,10 @@ func CalculateMetadata(totalRecords int64, page, pageSize int64) NmapMetadata {
 type NmapScanOut struct {
 	ID          string          `json:"id,omitempty" bson:"id"`
 	Status      string          `json:"status,omitempty"`
+	Summary     string          `json:"summary,omitempty"`
 	ScanType    api.NewScanType `json:"scan_type,omitempty"`
 	Description string          `json:"description,omitempty"`
-	HostArray   []string        `json:"hosts_array"`
+	HostArray   []string        `json:"hosts_array,omitempty"`
 	Args        string          `xml:"args,attr" json:"args"`
 	Scanner     string          `xml:"scanner,attr" json:"scanner"`
 	StartStr    string          `xml:"startstr,attr" json:"start_str"`
@@ -58,9 +59,10 @@ type NmapScanOut struct {
 type NmapScanIn struct {
 	ID               string              `json:"id"`
 	Status           string              `json:"status,omitempty"`
+	Summary          string              `json:"summary,omitempty"`
 	ScanType         string              `json:"scan_type,omitempty"`
 	Description      string              `json:"description,omitempty"`
-	ScanHosts        []string            `json:"scan_hosts"`
+	HostsArray       []string            `json:"hosts_array,omitempty"`
 	Args             string              `xml:"args,attr" json:"args"`
 	ProfileName      string              `xml:"profile_name,attr" json:"profile_name"`
 	Scanner          string              `xml:"scanner,attr" json:"scanner"`
@@ -102,9 +104,6 @@ func StartScan(ctx context.Context, s *api.Scan) (*nmap.Run, error) {
 
 // ScannerFactory is the factory which creates nmap.Scanner's.
 func ScannerFactory(ctx context.Context, targets, ports []string, scanType string) (*nmap.Scanner, error) {
-	// todo: this needs to be capable of accepting any number of options
-	// e.g. verbosity, NSE scripts by name and so on.
-
 	switch scanType {
 	case string(api.PortScan):
 		return nmap.NewScanner(

--- a/spec/oapi-spec.yaml
+++ b/spec/oapi-spec.yaml
@@ -28,7 +28,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageParam'
         - $ref: '#/components/parameters/PageSizeParam'
-
+        - $ref: '#/components/parameters/PageSortParam'
       responses:
         '200':
           description: Scan list response
@@ -38,12 +38,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Scan'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
     post:
       summary: Create a new Scan
       operationId: createScan
@@ -60,7 +54,32 @@ paths:
           description: Method not found
         '400':
           description: Bad request
-
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /scans/{id}:
+    get:
+      summary: Retrieve a single scan entry
+      operationId: retrieveScan
+      parameters:
+        - name: id
+          in: path
+          description: Scan ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Scan'
         default:
           description: Unexpected error
           content:
@@ -179,6 +198,13 @@ components:
       name: page_size
       in: query
       description: page size for pagination
+      required: false
+      schema:
+        type: string
+    PageSortParam:
+      name: sort
+      in: query
+      description: sort results
       required: false
       schema:
         type: string


### PR DESCRIPTION
Add support for:

- Retrieving a specific scan
- Add sort on list endpoint
- Provide `summary` to Scan object to provide more context to why a scan failed

It also provides some additional info about the NATS servers at start up. 