### PR TITLE
Updated schema and created hosted API endpoint at /docs

### DIFF
--- a/assets/templates/pages/elements.tmpl
+++ b/assets/templates/pages/elements.tmpl
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>On Picket | OpenAPI Specification</title>
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+    <style>
+      body {
+        font-family: ui-sans-serif, sans-serif;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+
+  <elements-api
+    id="docs"
+    router="hash"
+    layout="sidebar"
+    logo="https://danielms.site/favicons/favicon.ico"
+    apiDescriptionDocument="{{ .SpecString }}">
+  </elements-api>
+</html>

--- a/internal/nats/services.go
+++ b/internal/nats/services.go
@@ -63,9 +63,10 @@ func (n *Nats) startScanQueueGroup() error {
 				{Key: "$set", Value: bson.D{
 					{Key: "status", Value: string(api.InProgress)},
 					{Key: "id", Value: scan.Id},
-					{Key: "scan_type", Value: scan.Type},
+					{Key: "scan_type", Value: scan.ScanType},
 					{Key: "description", Value: scan.Description},
-					{Key: "hosts_array", Value: scan.Hosts},
+					{Key: "hosts_array", Value: scan.HostsArray},
+					{Key: "ports", Value: scan.Ports},
 				}},
 			}
 			_, err = n.DB.Collection(database.ScanCollection).UpdateOne(
@@ -108,9 +109,10 @@ func (n *Nats) startScanQueueGroup() error {
 			nmapResult := services.NmapScan{
 				ID:          scan.Id,
 				Status:      string(api.Complete),
-				ScanType:    api.NewScanType(scan.Type),
+				ScanType:    api.NewScanType(scan.ScanType),
 				Description: scan.Description,
-				HostsArray:  scan.Hosts,
+				HostsArray:  scan.HostsArray,
+				Ports:       scan.Ports,
 				Scan: services.NmapRun{
 					Args:        sRes.Args,
 					Scanner:     sRes.Scanner,

--- a/internal/response/templates.go
+++ b/internal/response/templates.go
@@ -8,6 +8,14 @@ import (
 	"net/http"
 )
 
+// ApiDocsPage is a custom page which does not inherit from any of the other templates.
+func ApiDocsPage(w http.ResponseWriter, status int, data any) error {
+	patterns := []string{"pages/elements.tmpl"}
+	headers := http.Header{}
+	headers.Add("Content-Type", "text/html; charset=utf-8")
+	return NamedTemplateWithHeaders(w, status, data, headers, "elements.tmpl", patterns...)
+}
+
 func Page(w http.ResponseWriter, status int, data any, pagePath string) error {
 	return PageWithHeaders(w, status, data, nil, pagePath)
 }

--- a/internal/server/api_handlers.go
+++ b/internal/server/api_handlers.go
@@ -120,8 +120,8 @@ func (app *Application) CreateScan(w http.ResponseWriter, r *http.Request) {
 	scan := api.Scan{
 		Id:          generateName(string(ns.Type)),
 		Ports:       ns.Ports,
-		Hosts:       ns.Hosts,
-		Type:        string(ns.Type),
+		HostsArray:  ns.Hosts,
+		ScanType:    string(ns.Type),
 		Status:      api.Scheduled,
 		Description: ns.Description,
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -38,7 +38,7 @@ func (app *Application) routes(openapi *openapi3.T) http.Handler {
 	router.Get("/status", app.status)
 	router.Group(func(web chi.Router) {
 		web.Get("/", app.home)
-		// web routes
+		web.Get("/docs", app.docs)
 	})
 
 	router.Group(func(oapi chi.Router) {

--- a/internal/server/web_handlers.go
+++ b/internal/server/web_handlers.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"encoding/json"
 	"github.com/danielmichaels/onpicket/internal/response"
 	"github.com/danielmichaels/onpicket/internal/version"
+	"github.com/danielmichaels/onpicket/pkg/api"
+	"github.com/getkin/kin-openapi/openapi3"
 	"net/http"
 )
 
@@ -23,5 +26,36 @@ func (app *Application) home(w http.ResponseWriter, r *http.Request) {
 	err := response.Page(w, http.StatusOK, data, "pages/home.tmpl")
 	if err != nil {
 		app.serverError(w, r, err)
+	}
+}
+
+func (app *Application) docs(w http.ResponseWriter, r *http.Request) {
+	data := app.newTemplateData(r)
+	openapi, err := api.GetSwagger()
+	if err != nil {
+		app.serverError(w, r, err)
+		return
+	}
+	loader := openapi3.NewLoader()
+	spec, err := json.Marshal(openapi)
+	if err != nil {
+		app.serverError(w, r, err)
+		return
+	}
+	doc, err := loader.LoadFromData(spec)
+	if err != nil {
+		app.serverError(w, r, err)
+		return
+	}
+	raw, err := doc.MarshalJSON()
+	if err != nil {
+		app.serverError(w, r, err)
+		return
+	}
+	data["SpecString"] = string(raw)
+	err = response.ApiDocsPage(w, http.StatusOK, data)
+	if err != nil {
+		app.serverError(w, r, err)
+		app.Logger.Error().Err(err).Send()
 	}
 }

--- a/internal/services/nmap.go
+++ b/internal/services/nmap.go
@@ -57,13 +57,14 @@ type NmapScan struct {
 	ScanType    api.NewScanType `json:"scan_type,omitempty" bson:"scan_type"`
 	Description string          `json:"description,omitempty" bson:"description"`
 	HostsArray  []string        `json:"hosts_array,omitempty" bson:"hosts_array"`
+	Ports       []string        `json:"ports" bson:"ports"`
 	Scan        NmapRun         `json:"data,omitempty" bson:"data"`
 }
 
 // StartScan is the entrypoint to creating Scan. A cancellable timeout and api.Scan
 // must be passed.
 func StartScan(ctx context.Context, s *api.Scan) (*nmap.Run, error) {
-	scanner, err := ScannerFactory(ctx, s.Hosts, s.Ports, s.Type)
+	scanner, err := ScannerFactory(ctx, s.HostsArray, s.Ports, s.ScanType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/client.gen.go
+++ b/pkg/api/client.gen.go
@@ -47,37 +47,196 @@ type Error struct {
 	Status string `json:"status"`
 }
 
-// Healthz defines model for Healthz.
+// Healthz Healthcheck endpoint for external monitoring.
 type Healthz struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
 }
 
-// NewScan defines model for NewScan.
+// NewScan Request body for creating a new scan.
 type NewScan struct {
-	Description string      `json:"description"`
-	Hosts       []string    `json:"hosts"`
-	Ports       []string    `json:"ports"`
-	Timeout     *int        `json:"timeout,omitempty"`
-	Type        NewScanType `json:"type"`
+	// Description user entered description for easier identification
+	Description string   `json:"description"`
+	Hosts       []string `json:"hosts"`
+
+	// Ports ports to scan. must be supplied in an array
+	Ports []string `json:"ports"`
+
+	// Timeout time in seconds
+	Timeout *int `json:"timeout,omitempty"`
+
+	// Type type of scan. must be one of the allowed types
+	Type NewScanType `json:"type"`
 }
 
-// NewScanType defines model for NewScan.Type.
+// NewScanType type of scan. must be one of the allowed types
 type NewScanType string
 
 // Scan defines model for Scan.
 type Scan struct {
+	// Data The entire response object for a single scan.
+	Data        ScanData   `json:"data"`
 	Description string     `json:"description"`
-	Hosts       []string   `json:"hosts"`
+	HostsArray  []string   `json:"hosts_array"`
 	Id          string     `json:"id"`
 	Ports       []string   `json:"ports"`
+	ScanType    string     `json:"scan_type"`
 	Status      ScanStatus `json:"status"`
-	Timeout     *int       `json:"timeout,omitempty"`
-	Type        string     `json:"type"`
+	Summary     string     `json:"summary"`
+
+	// Timeout time in seconds
+	Timeout *int `json:"timeout,omitempty"`
 }
 
 // ScanStatus defines model for Scan.Status.
 type ScanStatus string
+
+// ScanData The entire response object for a single scan.
+type ScanData struct {
+	// Args nmap command equivalent
+	Args     *string           `json:"args,omitempty"`
+	Hosts    *[]ScanHostsArray `json:"hosts,omitempty"`
+	Runstats *struct {
+		Finished *struct {
+			Elapsed  *float32 `json:"elapsed,omitempty"`
+			ErrorMsg *string  `json:"error_msg,omitempty"`
+			Exit     *string  `json:"exit,omitempty"`
+			Summary  *string  `json:"summary,omitempty"`
+			Time     *int64   `json:"time,omitempty"`
+			TimeStr  *string  `json:"time_str,omitempty"`
+		} `json:"finished,omitempty"`
+		Hosts *struct {
+			Down  *int `json:"down,omitempty"`
+			Total *int `json:"total,omitempty"`
+			Up    *int `json:"up,omitempty"`
+		} `json:"hosts,omitempty"`
+	} `json:"runstats,omitempty"`
+	ScanInfo *struct {
+		NumServices *int32  `json:"num_services,omitempty"`
+		Protocol    *string `json:"protocol,omitempty"`
+		ScanFlags   *string `json:"scan_flags,omitempty"`
+		Services    *string `json:"services,omitempty"`
+		Type        *string `json:"type,omitempty"`
+	} `json:"scan_info,omitempty"`
+	Scanner *string  `json:"scanner,omitempty"`
+	Start   *float32 `json:"start,omitempty"`
+
+	// StartStr scan start time
+	StartStr *string `json:"start_str,omitempty"`
+	Verbose  *struct {
+		Level *int `json:"level,omitempty"`
+	} `json:"verbose,omitempty"`
+
+	// Version nmap version on server
+	Version *string `json:"version,omitempty"`
+}
+
+// ScanHostsArray The detailed response from a single host during the scan event. Each host will have their own object within the hosts array.
+type ScanHostsArray struct {
+	Addresses *[]struct {
+		Addr     *string `json:"addr,omitempty"`
+		AddrType *string `json:"addr_type,omitempty"`
+		Vendor   *string `json:"vendor,omitempty"`
+	} `json:"addresses,omitempty"`
+	Comment  *string `json:"comment,omitempty"`
+	Distance *struct {
+		Value *int32 `json:"value,omitempty"`
+	} `json:"distance,omitempty"`
+	EndTime    *int64 `json:"end_time,omitempty"`
+	ExtraPorts *[]struct {
+		Count   *int32 `json:"count,omitempty"`
+		Reasons *[]struct {
+			Count  *int32  `json:"count,omitempty"`
+			Reason *string `json:"reason,omitempty"`
+		} `json:"reasons,omitempty"`
+		State *string `json:"state,omitempty"`
+	} `json:"extra_ports,omitempty"`
+	HostScripts *string `json:"host_scripts,omitempty"`
+	Hostnames   *[]struct {
+		Name *string `json:"name,omitempty"`
+		Type *string `json:"type,omitempty"`
+	} `json:"hostnames,omitempty"`
+	IpIdSequence *struct {
+		Class  *string `json:"class,omitempty"`
+		Values *string `json:"values,omitempty"`
+	} `json:"ip_id_sequence,omitempty"`
+	Os *struct {
+		OsFingerprints *string `json:"os_fingerprints,omitempty"`
+		OsMatches      *string `json:"os_matches,omitempty"`
+		PortsUsed      *string `json:"ports_used,omitempty"`
+	} `json:"os,omitempty"`
+	Ports *[]struct {
+		Id    *int32 `json:"id,omitempty"`
+		Owner *struct {
+			Name *string `json:"name,omitempty"`
+		} `json:"owner,omitempty"`
+		Protocol *string `json:"protocol,omitempty"`
+		Scripts  *[]struct {
+			Id     *string `json:"id,omitempty"`
+			Output *string `json:"output,omitempty"`
+			Tables *[]struct {
+				Elements *[]struct {
+					Key   *string `json:"key,omitempty"`
+					Value *string `json:"value,omitempty"`
+				} `json:"elements,omitempty"`
+			} `json:"tables,omitempty"`
+		} `json:"scripts,omitempty"`
+		Service *struct {
+			Confidence  *int32    `json:"confidence,omitempty"`
+			Cpes        *[]string `json:"cpes,omitempty"`
+			DeviceType  *string   `json:"device_type,omitempty"`
+			ExtraInfo   *string   `json:"extra_info,omitempty"`
+			HighVersion *string   `json:"high_version,omitempty"`
+			Hostname    *string   `json:"hostname,omitempty"`
+			LowVersion  *string   `json:"low_version,omitempty"`
+			Method      *string   `json:"method,omitempty"`
+			Name        *string   `json:"name,omitempty"`
+			OsType      *string   `json:"os_type,omitempty"`
+			Product     *string   `json:"product,omitempty"`
+			Proto       *string   `json:"proto,omitempty"`
+			RpcNum      *string   `json:"rpc_num,omitempty"`
+			ServiceFp   *string   `json:"service_fp,omitempty"`
+			Tunnel      *string   `json:"tunnel,omitempty"`
+			Version     *string   `json:"version,omitempty"`
+		} `json:"service,omitempty"`
+		State *struct {
+			Reason    *string `json:"reason,omitempty"`
+			ReasonIp  *string `json:"reason_ip,omitempty"`
+			ReasonTtl *int32  `json:"reason_ttl,omitempty"`
+			State     *string `json:"state,omitempty"`
+		} `json:"state,omitempty"`
+	} `json:"ports,omitempty"`
+	StartTime *int64 `json:"start_time,omitempty"`
+	Status    *struct {
+		Reason    *string `json:"reason,omitempty"`
+		ReasonTtl *int32  `json:"reason_ttl,omitempty"`
+		State     *string `json:"state,omitempty"`
+	} `json:"status,omitempty"`
+	TcpSequence *struct {
+		Difficulty *string `json:"difficulty,omitempty"`
+		Index      *int32  `json:"index,omitempty"`
+		Values     *string `json:"values,omitempty"`
+	} `json:"tcp_sequence,omitempty"`
+	TcpTsSequence *struct {
+		Class  *string `json:"class,omitempty"`
+		Values *string `json:"values,omitempty"`
+	} `json:"tcp_ts_sequence,omitempty"`
+	TimedOut *bool `json:"timed_out,omitempty"`
+	Times    *struct {
+		Rttv *string `json:"rttv,omitempty"`
+		Srtt *string `json:"srtt,omitempty"`
+		To   *string `json:"to,omitempty"`
+	} `json:"times,omitempty"`
+	Trace *struct {
+		Hops  *string `json:"hops,omitempty"`
+		Port  *int32  `json:"port,omitempty"`
+		Proto *string `json:"proto,omitempty"`
+	} `json:"trace,omitempty"`
+	Uptime *struct {
+		LastBoot *string `json:"last_boot,omitempty"`
+		Seconds  *int32  `json:"seconds,omitempty"`
+	} `json:"uptime,omitempty"`
+}
 
 // PageParam defines model for PageParam.
 type PageParam = string
@@ -88,7 +247,7 @@ type PageSizeParam = string
 // PageSortParam defines model for PageSortParam.
 type PageSortParam = string
 
-// ScanBody defines model for ScanBody.
+// ScanBody Request body for creating a new scan.
 type ScanBody = NewScan
 
 // ListScansParams defines parameters for ListScans.
@@ -96,10 +255,10 @@ type ListScansParams struct {
 	// Page page number for pagination
 	Page *PageParam `form:"page,omitempty" json:"page,omitempty"`
 
-	// PageSize page size for pagination
+	// PageSize page size for pagination. default is 20
 	PageSize *PageSizeParam `form:"page_size,omitempty" json:"page_size,omitempty"`
 
-	// Sort sort results
+	// Sort sort results by 'asc' or 'desc'. default is 'asc'
 	Sort *PageSortParam `form:"sort,omitempty" json:"sort,omitempty"`
 }
 
@@ -746,16 +905,16 @@ func ParseRetrieveScanResponse(rsp *http.Response) (*RetrieveScanResponse, error
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Healthcheck endpoint for the API
+	// Healthcheck
 	// (GET /healthz)
 	Healthz(w http.ResponseWriter, r *http.Request)
-	// Return all scans
+	// List Scans
 	// (GET /scans)
 	ListScans(w http.ResponseWriter, r *http.Request, params ListScansParams)
-	// Create a new Scan
+	// Create Scan
 	// (POST /scans)
 	CreateScan(w http.ResponseWriter, r *http.Request)
-	// Retrieve a single scan entry
+	// Retrieve Scan
 	// (GET /scans/{id})
 	RetrieveScan(w http.ResponseWriter, r *http.Request, id string)
 }
@@ -1001,23 +1160,56 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xX3W7bOBN9FYLfd6lYbnrT6q7tBtgsgjSIscACRWAw1NhiK5EsOYrXCfTuiyEly44k",
-	"11kU3QW6N4YszcyZn6PR4ROXprJGg0bPsydegMjBhcs/zm4FQqkqhWdX9Es3vSygEnSFWws840ojrMHx",
-	"pkkOPG6hEkorvX6hl4dv4TQJt8KJCrBN9Eas4Ybu0J8cvHTKojKaZ9yKNTBdV/fg2Mo4ZsVaaREeJlyR",
-	"xdca3JYnXIsKWgeeDOE9OqqFwAluoR6PQnr1CKcDLsn8FFTjcALVG4fMga9L9BNIZHIUpEm4g681eHxv",
-	"cgWhtwsp9HuTb+laGo2gw3iEtaWSoa70s6cM9kf2fwcrnvH/pT230vjUp9ewoZgR7rCG3xYfr5lZMQ0b",
-	"FmxiPspBzjN0NZBLG4dgLpwzji6sMxYctinft+m25Zn7zyCRNwmXJodh50IUFp4lfGVcJTDS7fU5Twbs",
-	"S7hHgbWfilOB95FCwxH2xXziLV4b7C4ZZvsriBKLx2F9fQLPIBL+AM6rOI3j8G2M3mMsg25UgwwOCh9J",
-	"ozA+bhOFUI1n2t4Qzokt/bfGvdQFVQWmxrEd0Rk/cdB1RQVT/KWPpPLgHpSEZa68NA/xHRncW+awEnVJ",
-	"TlTq/owmehqr7ko5JHfr2w+8SfgP663KR83+Rst76nV9pTe8BOy2V16XkIf9s7TOrB146sRKKLo97OCJ",
-	"Qzzed0WAL2s+hVB6ZSh4qSRoH3DaRfnOClkAO5/NecJrV/KMF4jWZ2m62WxmIjyeGbdOW1+fXl1+uLhe",
-	"XJydz+azAqsyloYlhfuob5T8Asje3VzuvXEZn8/ms1dkaSxoYRXP+OvZPKBagUXoc1r0a2AdP43ElrB5",
-	"L3Oe7dYE9cRbQ9mQ0fl8/qKVvePAsd3dYTUjyzs+Y6Bza5SmD823pMQYUuuTDh2OyYtTI/VOU7Lj9Ejk",
-	"EPvg66oSbrvrgSxAftk1IqgALCBMn8xT2kJ+cp5XyuMiWBzKnE/jyfUmaS+DmuQk417EnOqw0x/N3Y/g",
-	"WxQKz9fQkHtkx0rlgwIKOf2U9LsFrJ1moixZ5FhY8n6EZB8cCIQ9jRU133YqhwNZmO40YTMgwavvphOn",
-	"RGKY9c82ZmpCUCPfrb1RO4/093cNf1qQCDmD1mafY5E5TPQivd9p6ZPKm8nFdgvoFDx0rHu220aGfPlL",
-	"d5Chr2F/jgnf+8ODwbFTzb9rU9VSgveruvyPw/8YhzsmMsG80usSwrpkoNG1Q6PTQMfMXgBmaVoaKUrS",
-	"mtnbN2/fpCTamrvmrwAAAP//XFaowEURAAA=",
+	"H4sIAAAAAAAC/+xaeY/btrb/KoTeA5IGXmR5HfevNMlD05ebBJm2KNAGDi0eWWwkkiUpe5xgvvsFScnW",
+	"Qs9o0vTeC/T+M4u4neV3fjwkz+cg5rngDJhWwfpzkAImIO2fvwzfYQ0ZzakevjI/zUcCKpZUaMpZsA5Y",
+	"kW9BIp4gCX8UoLRCAmROtQaCDlSnlCGdAjpQRvghGAQqTiHHZiJ9FBCsA8o07EAGt7eDxoLvIMeUUbbr",
+	"taiseqMtJFwCgpsYgJgPZnk75cNWV+BRV9McEGWoYPQGHVJwykmsyyVKPZE0w9XdC94OAoElzkGX5n6L",
+	"d/DWfOmuK/AOUKl2wiUSeEcZto2DAG5wLjII1tEgoKb3HwXIYzAIGM6hHOwTRWlpzGsEMUtf0093Lq/o",
+	"J2gtPkIEElxkGlGForAuyzy8LMzGTNVHIi71BYkUl9pYuci0QtsjeoRV/AhxiR6Zfo8agtm2umwBVnHg",
+	"F8/Me6dkt4OgBN13nFCwjruOMfuOk6P5O+ZMA7PQwUJkNLaGGv+ujNifaxP/r4QkWAf/Mz6H39i1qvFr",
+	"OJg53XJNxX+4fvPaIJ/BAdk+Th4qgQRrLQswQ8p5zDIvpOTS/CEkFyB1KfK2FLdUj29/h1gHt4Mg5gS6",
+	"5razINs2CBIuc6wdlqdRMOhAexAojXWhLs2Tg1IOk12/n5X5NSjXKyd7P+hK+z3gTKefugu5hjiF+CMC",
+	"RgSnTFvwwo0GyXCGcs6o5mbdUTBoWecs/hkzb/6/K+8g2INU1Ln23DWMo+VsfjWLF/MQ5uF0Pg3xbDuF",
+	"aBZuCSzCeLGdzwncb4BSjvMyPhtUYOnY4J3DKTK+trrHErA2lIgtfFSMWVf3xhztKQsFEgHTIIGgWpMz",
+	"LVYUJKIEmKZJifxG3D1/fY10LBBmBBVEWAl8Vk250k3z/xrsON9lMIp5bqIVdEaTo/3v/SCgGnLlidbT",
+	"1FhKfDT/Cy61B5f2M9Lc2QTlhTEbIFWYEAZiKB8z5GYZ1KWKDP7n02AQLMIwDIeLaRiGDxPJ7Cm8uGOz",
+	"URBzRlR9YbOKL+7cl85ERwGGM5rKcWY/mg0MZxk/AEGmo12HFbnRzphlUzpJgdzTGDaEqpjvHWl2vm1K",
+	"2t245etBewHiztWVY5psV449M8DtIKig3gIt1veSqhn53PRrc2o9dPMj8kjQwebGee+vQCglTYnutfEw",
+	"vFpMV1fx3CftCe8ezD5ILIOCTQWvs3R1hHTmqNFoCSjjlgx0tfmTIgNid+KNkHwnQRkIJJiaz+/rzFEb",
+	"2F2myHMsjy2zFXEMSiVFdpFlvl7gtTBNjU51nJzhXclaN2gb9CfWt6h+X1PQoh856reUi9GO7oGVVF6G",
+	"x/MyGJpK/ZiCYW4qweRNgjMFzZkUZbsMLuwKWO48tMlyLFDM89wQujHAHmcm+al7blwoOd5SNradhwJN",
+	"hoswREP1MxqqZ2jIf0FD1Aidy9vBCa73xfn3ZsTTE8O2sCwLZmysujySUEZVCqTbAhkWCpqxGa1G0Wl2",
+	"l52b6cEkOZtc7byBBTfuHNWBam9ovzaGJIa+sUbXWKMfCobQFEXTdTRdz1coCqPptyhCL98iTIiJKlDo",
+	"cYSsHVEhvrFOZm5fM0qENah7w6QhwHARTabz+dViZWKhng0uZt5s0MywUVo21bgkuTcr6mQ9J0y0NgJ+",
+	"YL7T1iDQXOPM31SICyfC1qo+OWwYU5bwriysyDclezcp2KYKvfJoIbnmMc+altOx8ILFiJJkeOdndK8o",
+	"gY3GMPQ6vsP2MWfM6N3LQw5j0i+LxlLXWs7BY1sqsLTOfIb8bDuymBxcBFMYrufLC2CyyfSWK+g6LIM9",
+	"ZP2g0Mj8PaRYtiJudhG5B9mQdjm66gnzFpl5WZ2AtjvmmdcTyfMzo5tQQaSQ1WWItSPsgekReoHj1HU4",
+	"0CxDKd6D6UMl4ofTTlO7x3EUYpnUs0lUZNPg6m6fFgKX4WgxG02m0WgSRT6HmTGe3IOK/czvX0a49F8r",
+	"dAzc3hvMblae3zsTE6o0ZrEHOXucFU3p+sS3Tx5gZPPnGRdutMSbU/J3wRcxL1hzL5pfzXvxkgSsOPsr",
+	"52662t6n9YuYTuKqsW7TWMaVzTu/YDoTAKfTjckYKoVYkWV4m8GlBIbh/M7AcBdQdTETNiKYqSLTIyVw",
+	"DP042hzRv0w1KjaUbBT8UYAX5HGGlX9rsfBXPSOOe5TnapNQtgMpJGUPMCxXmxzrOIX+Q2xQbIoyl+sx",
+	"xKfDfZHVOsRFUS/k80O5X/qR0Ueuh+ULJxT3UyNQKh0aLH+Eo9cbhRZFK7mdhssILWFKVqsrPFmu8HQx",
+	"wzieJFfzFcCKhJNJTNDjd9dPv0HRfIGShJBJlITLaIvDKbmar+awna8W8Qrmy+l0ix6/ePa86rxchCFe",
+	"JqsFzDAhW1hOyWo5C0mULFbLRXSFHr94Hs3nk6tvvLFj/H2X+pBBXj2LXOhiLNG0tTvR+UOka02p8JcE",
+	"69foccoIfeTNEkoqFjhJPOmXtMaiZdUa8wpYj/GaC2BbRexvpdL1ahSJyWV6O0tMwN6FVKznOVyZfa9K",
+	"x8/r/rQtmC7QK8qKm29RFSUoGnkT35Tu0k0tv7vI597GjB/uHJyDTnkrsITkW9+ONPBsC0qlF6iwuxlY",
+	"hb0sKDkp4lasvhHArq+/v9Bfc686UsQbe7tz+cixSYT/jqlgrJFw33OvbmGCSl/OCvs7HM17HkeqPKAJ",
+	"dV+2oY5siOOPPju47hvqV6hs1bpJwLOo96NJy38mQPqo1zMRkvor5JbnW72vYcmvZ6tC9GTSWNyR5BCa",
+	"JDQuMn30epgyAjcPTvQfmCEZCbX66zMxgwWyKa9Ay9Yt5xlgVjX7/Kz1vmGB5XLpyy6kbtJLtIimi4WP",
+	"5Hmr33y2nPVzpcQ+86RcPCwf/AKHXiJEn5iFqKKudd+Ald5sOdcXyNNdyf35U6Xni4Wy2yWbFwpvGHpL",
+	"449gX84xO7+XKogLSfURYaVAoxwzvLPpEdKcZyjhcaEo2yHOEC40z7EG4u4Z7dcEHXlRe34VIKktfRih",
+	"34ownMZbaX9D+9+TQI8U4iw7lneXEimOEiyNmB9YjsWHEfoZ5BElcCg/VDfTCmHp3vK41O7SU6dUVXc0",
+	"I/QPLsHdfyQ8y/gBYeWexc4P+EgCNscMRI0cCZVKIwkZYAX3KfDkyWuu4cmT9vcfjQz1Jagyoj3NRIoR",
+	"gT1kXFj7YkZQjo/uciax1QdMo60E/NGYNk4x24FCQlIukeZWdCchN1xGcXYSNRgEGY2BuduvsubhqTCq",
+	"lclQIbNgHaRaC7Uejw+Hwwjb5hGXu3E5Vo1fvXz24vX1i2E0CkepzjNHF9plEawE0NO3L2tP1+sgHIWj",
+	"iU1VBDAsqDkdjEK7qsA6tUgfp+cX/Z2vAuehD/sm3qx5X5LT6E+2aMLdldlVozB8UO1Gr3eIaq1bTxXH",
+	"tb0TNB4v3Gu4E4eY0B/cW4LlW7UcM+4OuKuuqu9M50GX6qT6z2QGOJuc37VqXrV0NTZBri6C4BVVGuEs",
+	"sxUwyl13GtQTrPHW4Pw39n8002CvPKmqxT5315gVcroIMVPbWYNmedavfhXPXcbn8q3bQa/O54KrvgNO",
+	"9VC37/8VCHY1SJ2TZRfNMWYoo5YSnUx/SxBbVDrs2LxC2Tmb8HomAWuoFW65QrLjpdUbtWbjU6HZbcf9",
+	"k69WfHap8sx6+e/mYGMEW23x1czrCvI89v2JwY2A2LAUlH3q6HLIQaV3Koocf6bk9iJPvgMtKeyh+bpf",
+	"Petsj4hqhT5Q8qFDg9XIEqktJvQA4+XzqqLS7OXngkpbC9GsULyrvPI/i9fONST/xf2/C/cnDJ95yb2o",
+	"+qD41l1ruTqaZirLmbBp6Sjm+dhkn2bTbaUVPMZZPfVuTLIejzPTIeVKr69WVys3y/vbfwYAAP//MOpO",
+	"kkIvAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/spec/oapi-spec.yaml
+++ b/spec/oapi-spec.yaml
@@ -2,20 +2,38 @@ openapi: "3.0.0"
 info:
   version: "0.0.1"
   title: "OnPicket API"
-  description: ""
+  description:
+    On Picket is an external security asset management tool focusing on automated
+    scanning of your external perimeter.
+    <br>
+    <br>
+    On Picket's only scanner so far is `nmap`. Very few `nmap` commands are supported in
+    this version. More will follow as the application reaches it's first release.
+    <br>
+    <br>
+    **Note**
+    <br>
+    This application is in Alpha development and may have frequent breaking changes
+    prior to the first official release.
+
   license:
     name: "Apache 2.0"
     url: "https://www.apache.org/licenses/LICENSE-2.0.html"
 servers:
+  - url: https://onpicket.com/api
+    description: Production
   - url: http://localhost:9898/api
+    description: Local development
 paths:
   /healthz:
     get:
-      summary: Healthcheck endpoint for the API
+      summary: Healthcheck
+      description:
+        Healthcheck endpoint for external monitoring.
       operationId: healthz
       responses:
         '200':
-          description: Health endpoint
+          description: Server is up and responding
           headers:
             X-Ratelimit-Limit:
               $ref: '#/components/headers/X-Ratelimit-Limit'
@@ -30,7 +48,11 @@ paths:
                   $ref: '#/components/schemas/Healthz'
   /scans:
     get:
-      summary: Return all scans
+      summary: List Scans
+      description:
+        List all Scans from the database.
+
+        Filtering is supported on the endpoint.
       operationId: listScans
       parameters:
         - $ref: '#/components/parameters/PageParam'
@@ -53,7 +75,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Scan'
     post:
-      summary: Create a new Scan
+      summary: Create Scan
       operationId: createScan
       requestBody:
         $ref: '#/components/requestBodies/ScanBody'
@@ -79,7 +101,9 @@ paths:
                 $ref: '#/components/schemas/Error'
   /scans/{id}:
     get:
-      summary: Retrieve a single scan entry
+      summary: Retrieve Scan
+      description:
+        Retrieve a single scan object by its `id`
       operationId: retrieveScan
       parameters:
         - name: id
@@ -115,41 +139,54 @@ paths:
 components:
   headers:
     X-Ratelimit-Limit:
+      description: number of requests permitted within the window
       schema:
         type: integer
     X-Ratelimit-Remaining:
+      description: number of requests remaining before exceeding the limit
       schema:
         type: integer
     X-Ratelimit-Reset:
+      description: time in unix when the rate limit window resets
       schema:
         type: integer
 
   schemas:
     Scan:
+      summary:
+        Scan object for a given scan.
       required:
         - id
-        - hosts
+        - hosts_array
         - ports
+        - summary
+        - scan_type
         - description
-        - type
         - status
+        - data
       properties:
         id:
           type: string
-        hosts:
+          example: service_discovery_default_scripts-096389c5
+        hosts_array:
           type: array
+          example: [ "google.com", "netlify.com" ]
           items:
             type: string
         ports:
           type: array
+          example: [ "22", "53" ]
           items:
             type: string
-        type:
+        scan_type:
           type: string
-        timeout:
-          type: integer
+          example: port_scan
         description:
           type: string
+          example: my description
+        summary:
+          type: string
+          example: successful scan
         status:
           type: string
           enum:
@@ -157,8 +194,17 @@ components:
             - scheduled
             - in_progress
             - failed
+          example: complete
+        timeout:
+          type: integer
+          description: time in seconds
+          example: 3000
+        data:
+          $ref: '#/components/schemas/ScanData'
 
     NewScan:
+      description:
+        Request body for creating a new scan.
       required:
         - hosts
         - ports
@@ -168,21 +214,29 @@ components:
       properties:
         hosts:
           type: array
+          example: [ "google.com", "netlify.com" ]
           items:
             type: string
         ports:
           type: array
+          description: ports to scan. must be supplied in an array
+          example: [ "22", "53", "60000-63000" ]
           items:
             type: string
         timeout:
           type: integer
+          description: time in seconds
+          example: 3000
         type:
           type: string
+          description: type of scan. must be one of the allowed types
           enum:
             - port_scan
             - service_discovery
             - service_discovery_default_scripts
         description:
+          description: user entered description for easier identification
+          example: DNS tcp and udp scan
           type: string
 
     Error:
@@ -202,6 +256,8 @@ components:
           type: object
 
     Healthz:
+      description:
+        Healthcheck endpoint for external monitoring.
       type: object
       required:
         - status
@@ -209,8 +265,382 @@ components:
       properties:
         status:
           type: string
+          example: "OK"
         version:
           type: string
+          example: "0c274594c650e503530a4b3e240bde60c6b55dee"
+
+    ScanData:
+      description:
+        The entire response object for a single scan.
+      type: object
+      properties:
+        args:
+          type: string
+          description: nmap command equivalent
+          example: "/usr/bin/nmap -p 1-600 -sV -sC -oX - google.com"
+        scanner:
+          type: string
+        start_str:
+          type: string
+          description: scan start time
+          example: "Sat Jun  3 23:00:57 2023"
+        version:
+          type: string
+          description: nmap version on server
+          example: "7.93"
+        runstats:
+          type: object
+          properties:
+            finished:
+              type: object
+              properties:
+                time:
+                  type: integer
+                  format: int64
+                  example: -62135596800
+                time_str:
+                  type: string
+                  example: Sat Jun  3 23:23:58 2023
+                elapsed:
+                  type: number
+                  example: 28.2
+                summary:
+                  type: string
+                  example: Nmap done at Sat Jun  3 23:23:58 2023; 2 IP addresses (2 hosts up) scanned in 28.20 seconds
+                exit:
+                  type: string
+                  example: success
+                error_msg:
+                  type: string
+            hosts:
+              type: object
+              properties:
+                up:
+                  type: integer
+                down:
+                  type: integer
+                total:
+                  type: integer
+        scan_info:
+          type: object
+          properties:
+            num_services:
+              type: integer
+              format: int32
+              example: 60000
+            protocol:
+              type: string
+              example: tcp
+            scan_flags:
+              type: string
+              example:
+            services:
+              type: string
+              example: 1-60000
+            type:
+              type: string
+              example: connect
+        start:
+          type: number
+        verbose:
+          type: object
+          properties:
+            level:
+              type: integer
+        hosts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScanHostsArray'
+
+
+    ScanHostsArray:
+      type: object
+      description:
+        The detailed response from a single host during the scan event. Each host
+        will have their own object within the hosts array.
+      properties:
+        distance:
+          type: object
+          properties:
+            value:
+              type: integer
+              format: int32
+              example: 0
+        end_time:
+          type: integer
+          format: int64
+          example: -62135596800
+        ip_id_sequence:
+          type: object
+          properties:
+            class:
+              type: string
+              example:
+            values:
+              type: string
+              example:
+        os:
+          type: object
+          properties:
+            ports_used:
+              type: string
+              format: nullable
+            os_matches:
+              type: string
+              format: nullable
+            os_fingerprints:
+              type: string
+              format: nullable
+        start_time:
+          type: integer
+          format: int64
+          example: -62135596800
+        timed_out:
+          type: boolean
+        status:
+          type: object
+          properties:
+            state:
+              type: string
+              example: up
+            reason:
+              type: string
+              example: syn-ack
+            reason_ttl:
+              type: integer
+              format: int32
+              example: 42
+        tcp_sequence:
+          type: object
+          properties:
+            index:
+              type: integer
+              format: int32
+              example: 0
+            difficulty:
+              type: string
+              example:
+            values:
+              type: string
+              example:
+        tcp_ts_sequence:
+          type: object
+          properties:
+            class:
+              type: string
+              example:
+            values:
+              type: string
+              example:
+        times:
+          type: object
+          properties:
+            srtt:
+              type: string
+              example: 262366
+            rttv:
+              type: string
+              example: 777
+            to:
+              type: string
+              example: 265474
+        trace:
+          type: object
+          properties:
+            proto:
+              type: string
+              example:
+            port:
+              type: integer
+              format: int32
+              example: 0
+            hops:
+              type: string
+              format: nullable
+        uptime:
+          type: object
+          properties:
+            seconds:
+              type: integer
+              format: int32
+              example: 0
+            last_boot:
+              type: string
+              example:
+        comment:
+          type: string
+          example:
+        addresses:
+          type: array
+          items:
+            type: object
+            properties:
+              addr:
+                type: string
+                example: 170.64.132.122
+              addr_type:
+                type: string
+                example: ipv4
+              vendor:
+                type: string
+                example:
+        extra_ports:
+          type: array
+          items:
+            type: object
+            properties:
+              state:
+                type: string
+                example: closed
+              count:
+                type: integer
+                format: int32
+                example: 595
+              reasons:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    reason:
+                      type: string
+                      example: reset
+                    count:
+                      type: integer
+                      format: int32
+                      example: 595
+        hostnames:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                example: fn.dansult.space
+              type:
+                type: string
+                example: user
+        host_scripts:
+          type: string
+          format: nullable
+        ports:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int32
+                example: 22
+              protocol:
+                type: string
+                example: tcp
+              owner:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    example:
+              service:
+                type: object
+                properties:
+                  device_type:
+                    type: string
+                    example:
+                  extra_info:
+                    type: string
+                    example: Ubuntu Linux; protocol 2.0
+                  high_version:
+                    type: string
+                    example:
+                  hostname:
+                    type: string
+                    example:
+                  low_version:
+                    type: string
+                    example:
+                  method:
+                    type: string
+                    example: probed
+                  name:
+                    type: string
+                    example: ssh
+                  os_type:
+                    type: string
+                    example: Linux
+                  product:
+                    type: string
+                    example: OpenSSH
+                  proto:
+                    type: string
+                    example:
+                  rpc_num:
+                    type: string
+                    example:
+                  service_fp:
+                    type: string
+                    example:
+                  tunnel:
+                    type: string
+                    example:
+                  version:
+                    type: string
+                    example: 8.2p1 Ubuntu 4ubuntu0.5
+                  confidence:
+                    type: integer
+                    format: int32
+                    example: 10
+                  cpes:
+                    type: array
+                    items:
+                      type: string
+                      example: cpe:/a:openbsd:openssh:8.2p1
+              state:
+                type: object
+                properties:
+                  state:
+                    type: string
+                    example: open
+                  reason:
+                    type: string
+                    example: syn-ack
+                  reason_ip:
+                    type: string
+                    example:
+                  reason_ttl:
+                    type: integer
+                    format: int32
+                    example: 42
+              scripts:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      example: ssh-hostkey
+                    output:
+                      type: string
+                      example:
+                        3072 7e3d889a178a364aac1f958ee8d011cd (RSA)
+                        256 ffdd12f072ba03d9585eb586c8e5733b (ECDSA)
+                        256 7600a7f86e4addbe73d8740d2f687629 (ED25519)
+                    tables:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          elements:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                  example: type
+                                value:
+                                  type: string
+                                  example: ssh-rsa
 
   requestBodies:
     ScanBody:
@@ -226,20 +656,23 @@ components:
       name: page
       in: query
       description: page number for pagination
+      example: 2
       required: false
       schema:
         type: string
     PageSizeParam:
       name: page_size
       in: query
-      description: page size for pagination
+      description: page size for pagination. default is 20
+      example: 50
       required: false
       schema:
         type: string
     PageSortParam:
       name: sort
       in: query
-      description: sort results
+      description: sort results by 'asc' or 'desc'. default is 'asc'
+      example: asc
       required: false
       schema:
         type: string


### PR DESCRIPTION
The API schema has been improved greatly with examples and descriptions added through out.

This necessitated some alterations and additions to the schema and API changes.

`/docs` now hosts a working [spotlight] API page with runnable examples.

[spotlight]: https://stoplight.io
