### PR TITLE
Adds VCS info and js/css assets to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
+FROM node:alpine as node
+RUN mkdir -p /build
+WORKDIR /build
+COPY . .
+RUN yarn &&\
+    mkdir -p /build/assets/static/css/ &&\
+    mkdir -p /build/assets/static/js/ &&\
+    yarn tailwind &&\
+    yarn alpine
+
 FROM golang:1.20-alpine AS builder
 
-# Move to working directory (/build).
 WORKDIR /build
 
 # only copy mod file for better caching
 COPY go.mod go.mod
 RUN go mod download
 
+COPY --from=node ["/build/assets/static/css/theme.css", "/build/assets/static/css/theme.css"]
+COPY --from=node ["/build/assets/static/js/bundle.js", "/build/assets/static/js/bundle.js"]
+
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-# copy files
+
 COPY . .
-RUN go build  \
+RUN apk add git &&\
+    go build  \
     -ldflags="-s -w" \
     -o app github.com/danielmichaels/onpicket/cmd/app
 
@@ -18,5 +31,4 @@ FROM instrumentisto/nmap
 
 COPY --from=builder ["/build/app", "/usr/bin/app"]
 
-## Command to run when starting the container.
 ENTRYPOINT ["app"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "tailwind": "tailwindcss -i assets/static/css/main.css -o assets/static/css/theme.css -m",
+    "alpine": "npx esbuild index.js --outfile=assets/static/js/bundle.js --bundle --minify"
+  },
+  "devDependencies": {
+    "@tailwindcss/aspect-ratio": "^0.4.2",
+    "@tailwindcss/forms": "^0.5.3",
+    "@tailwindcss/typography": "^0.5.8",
+    "tailwindcss": "^3.2.4"
+  },
+  "dependencies": {
+    "alpinejs": "^3.10.5",
+    "esbuild": "^0.15.14"
+  }
+}


### PR DESCRIPTION
The js/css assets are build on demand and thus omitted from VCS. This breaks the build when not running locally. The dockerfile now builds them and places them into the path for inclusion in the binary.

VCS info is now included correctly in the image as well. 